### PR TITLE
adding argument for api-key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the sou
 | `registry-username` | The registry username to use when authenticating to an external registry                                                                                                                                                                                         |               |
 | `registry-password` | The registry password to use when authenticating to an external registry                                                                                                                                                                                         |               |
 | `fail-build`        | Fail the build if an end-of-life (EOL) software is found                                                                                                                   | `true`        |
+| `api-key`        | The API key to use to send results to xeol.io                                                                                                                   | N/A        |
 | `output-format`     | Set the output parameter after successful action execution. Valid choices are `json`, and `table`, where `table` output will print to the console instead of generating a file.                                                                         | `table`       |
 
 

--- a/index.js
+++ b/index.js
@@ -87,10 +87,12 @@ async function run() {
     // a check must happen to ensure one is selected at least, and then return it
     const source = sourceInput();
     const failBuild = core.getInput("fail-build") || "true";
+    const apiKey = core.getInput("api-key") || "";
     const outputFormat = core.getInput("output-format") || "table";
     const out = await runScan({
       source,
       failBuild,
+      apiKey,
       outputFormat,
     });
     Object.keys(out).map((key) => {
@@ -104,6 +106,7 @@ async function run() {
 async function runScan({
   source,
   failBuild,
+  apiKey,
   outputFormat,
 }) {
   const out = {};
@@ -163,6 +166,9 @@ async function runScan({
   let cmd = `${xeolBinary}`;
   if (failBuild) {
     cmdArgs.push("--fail-on-eol-found");
+  }
+  if (apiKey) {
+    cmdArgs.push("--api-key", apiKey);
   }
   cmdArgs.push(source);
 


### PR DESCRIPTION
adds a cmd argument for the xeol-action that allows you use set an api-key to use with xeol.io